### PR TITLE
feat: Add lead tracking feature with CRUD functionality

### DIFF
--- a/src/e2e/test_e2e.py
+++ b/src/e2e/test_e2e.py
@@ -1,7 +1,91 @@
 import re
 from playwright.sync_api import Page, expect
 
+BASE_URL = "http://web:5000"
+
+def login(page: Page, username="test", password="test"):
+    page.goto(f"{BASE_URL}/auth/login")
+    page.locator('input[name="username"]').fill(username)
+    page.locator('input[name="password"]').fill(password)
+    page.locator('input[type="submit"]').click()
+    expect(page).to_have_url(re.compile(r".*/$")) # Should redirect to index
+
 def test_index(page: Page):
-    page.goto("http://web:5000")
+    page.goto(BASE_URL)
     expect(page.locator(".navbar .navbar-brand")).to_be_visible()
     expect(page.locator(".navbar .navbar-brand")).to_have_text("Flaskr")
+
+def test_navigate_to_leads_and_see_empty(page: Page):
+    login(page)
+    page.locator('nav >> text=Leads').click()
+    expect(page).to_have_url(f"{BASE_URL}/lead/")
+    expect(page.locator('h1')).to_have_text("Leads")
+    expect(page.get_by_text("No leads found.")).to_be_visible()
+    expect(page.get_by_role("link", name="Add Lead")).to_be_visible()
+
+def test_add_lead(page: Page):
+    login(page)
+    page.goto(f"{BASE_URL}/lead/")
+    page.get_by_role("link", name="Add Lead").click()
+    expect(page).to_have_url(f"{BASE_URL}/lead/create")
+
+    page.locator('input[name="title"]').fill("E2E Test Lead")
+    page.locator('input[name="start_date"]').fill("2024-01-01")
+    page.locator('input[name="end_date"]').fill("2024-01-31")
+    page.locator('input[name="amount"]').fill("1000.50")
+    page.locator('input[name="probability"]').fill("0.75")
+    page.locator('input[type="submit"][value="Save"]').click()
+
+    expect(page).to_have_url(f"{BASE_URL}/lead/")
+    row = page.locator("table tbody tr", has_text="E2E Test Lead")
+    expect(row.locator("td:nth-child(1)")).to_have_text("E2E Test Lead")
+    expect(row.locator("td:nth-child(2)")).to_have_text("2024-01-01")
+    expect(row.locator("td:nth-child(3)")).to_have_text("2024-01-31")
+    expect(row.locator("td:nth-child(4)")).to_have_text("1000.5") # Float representation might vary slightly
+    expect(row.locator("td:nth-child(5)")).to_have_text("0.75")
+
+
+def test_edit_lead(page: Page):
+    # This test depends on 'test_add_lead' having run successfully and the lead existing.
+    # For more robust E2E, create the lead needed for this test within the test or a setup step.
+    # For now, we assume "E2E Test Lead" exists.
+    login(page)
+    page.goto(f"{BASE_URL}/lead/")
+
+    # Find the row and click Edit
+    row = page.locator("table tbody tr", has_text="E2E Test Lead")
+    row.get_by_role("link", name="Edit").click()
+    
+    expect(page).to_have_url(re.compile(r".*/lead/\d+/update"))
+    expect(page.locator('input[name="title"]')).to_have_value("E2E Test Lead")
+
+    page.locator('input[name="title"]').fill("E2E Test Lead Updated")
+    page.locator('input[name="amount"]').fill("1200.75")
+    page.locator('input[type="submit"][value="Save"]').click()
+
+    expect(page).to_have_url(f"{BASE_URL}/lead/")
+    updated_row = page.locator("table tbody tr", has_text="E2E Test Lead Updated")
+    expect(updated_row.locator("td:nth-child(1)")).to_have_text("E2E Test Lead Updated")
+    expect(updated_row.locator("td:nth-child(4)")).to_have_text("1200.75")
+    # Check other fields remained
+    expect(updated_row.locator("td:nth-child(2)")).to_have_text("2024-01-01") 
+    expect(updated_row.locator("td:nth-child(5)")).to_have_text("0.75")
+
+def test_delete_lead(page: Page):
+    # Assumes "E2E Test Lead Updated" exists from the previous test.
+    login(page)
+    page.goto(f"{BASE_URL}/lead/")
+
+    row = page.locator("table tbody tr", has_text="E2E Test Lead Updated")
+    expect(row).to_be_visible() # Ensure it exists before trying to delete
+
+    # Handle the JavaScript confirmation dialog
+    page.on("dialog", lambda dialog: dialog.accept())
+    
+    row.get_by_role("button", name="Delete").click() # Or input[type="submit"] if it's a form
+
+    expect(page).to_have_url(f"{BASE_URL}/lead/")
+    expect(page.get_by_text("E2E Test Lead Updated")).not_to_be_visible()
+    # Optionally, check for "No leads found." if this was the only lead.
+    # This depends on test isolation. If other leads could exist, this check is less reliable.
+    # For now, we only check that the specific lead is gone.

--- a/src/flask/flaskr/__init__.py
+++ b/src/flask/flaskr/__init__.py
@@ -35,6 +35,10 @@ def create_app(test_config=None):
 
     from . import blog
     app.register_blueprint(blog.bp)
+
+    from . import lead
+    app.register_blueprint(lead.bp)
+
     app.add_url_rule('/', endpoint='index')
 
     return app

--- a/src/flask/flaskr/lead.py
+++ b/src/flask/flaskr/lead.py
@@ -1,0 +1,150 @@
+from flask import (
+    Blueprint, flash, g, redirect, render_template, request, url_for
+)
+from werkzeug.exceptions import abort
+
+from flaskr.auth import login_required
+from flaskr.db import get_db
+
+bp = Blueprint('lead', __name__, url_prefix='/lead')
+
+@bp.route('/')
+def index():
+    db = get_db()
+    leads = db.execute(
+        'SELECT id, title, start_date, end_date, amount, probability'
+        ' FROM lead'
+        ' ORDER BY id DESC'
+    ).fetchall()
+    return render_template('lead/index.html', leads=leads)
+
+@bp.route('/create', methods=('GET', 'POST'))
+@login_required
+def create():
+    if request.method == 'POST':
+        title = request.form['title']
+        start_date_str = request.form.get('start_date')
+        end_date_str = request.form.get('end_date')
+        amount_str = request.form.get('amount')
+        probability_str = request.form.get('probability')
+
+        error = None
+
+        if not title:
+            error = 'Title is required.'
+
+        start_date = start_date_str if start_date_str else None
+        end_date = end_date_str if end_date_str else None
+        
+        amount = None
+        if amount_str:
+            try:
+                amount = float(amount_str)
+            except ValueError:
+                error = 'Invalid amount.'
+                # If there's already an error, append to it or handle appropriately
+                if error and error != 'Invalid amount.':
+                     error += ' Invalid amount.'
+                else:
+                    error = 'Invalid amount.'
+        
+        probability = None
+        if probability_str:
+            try:
+                probability = float(probability_str)
+            except ValueError:
+                 # If there's already an error, append to it or handle appropriately
+                if error and error != 'Invalid probability.':
+                     error += ' Invalid probability.'
+                else:
+                    error = 'Invalid probability.'
+
+
+        if error is not None:
+            flash(error)
+        else:
+            db = get_db()
+            db.execute(
+                'INSERT INTO lead (title, start_date, end_date, amount, probability)'
+                ' VALUES (?, ?, ?, ?, ?)',
+                (title, start_date, end_date, amount, probability)
+            )
+            db.commit()
+            return redirect(url_for('lead.index'))
+
+    return render_template('lead/create.html')
+
+def get_lead(id):
+    lead = get_db().execute(
+        'SELECT id, title, start_date, end_date, amount, probability'
+        ' FROM lead'
+        ' WHERE id = ?',
+        (id,)
+    ).fetchone()
+
+    if lead is None:
+        abort(404, f"Lead id {id} doesn't exist.")
+
+    return lead
+
+@bp.route('/<int:id>/update', methods=('GET', 'POST'))
+@login_required
+def update(id):
+    lead = get_lead(id)
+
+    if request.method == 'POST':
+        title = request.form['title']
+        start_date_str = request.form.get('start_date')
+        end_date_str = request.form.get('end_date')
+        amount_str = request.form.get('amount')
+        probability_str = request.form.get('probability')
+        error = None
+
+        if not title:
+            error = 'Title is required.'
+
+        start_date = start_date_str if start_date_str else None
+        end_date = end_date_str if end_date_str else None
+
+        amount = None
+        if amount_str:
+            try:
+                amount = float(amount_str)
+            except ValueError:
+                if error:
+                    error += ' Invalid amount.'
+                else:
+                    error = 'Invalid amount.'
+        
+        probability = None
+        if probability_str:
+            try:
+                probability = float(probability_str)
+            except ValueError:
+                if error:
+                    error += ' Invalid probability.'
+                else:
+                    error = 'Invalid probability.'
+
+        if error is not None:
+            flash(error)
+        else:
+            db = get_db()
+            db.execute(
+                'UPDATE lead SET title = ?, start_date = ?, end_date = ?, amount = ?, probability = ?'
+                ' WHERE id = ?',
+                (title, start_date, end_date, amount, probability, id)
+            )
+            db.commit()
+            return redirect(url_for('lead.index'))
+
+    return render_template('lead/update.html', lead=lead)
+
+@bp.route('/<int:id>/delete', methods=('POST',))
+@login_required
+def delete(id):
+    get_lead(id) # Check if lead exists
+    db = get_db()
+    db.execute('DELETE FROM lead WHERE id = ?', (id,))
+    db.commit()
+    return redirect(url_for('lead.index'))

--- a/src/flask/flaskr/schema.sql
+++ b/src/flask/flaskr/schema.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS user;
 DROP TABLE IF EXISTS post;
+DROP TABLE IF EXISTS lead;
 
 CREATE TABLE user (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -14,4 +15,13 @@ CREATE TABLE post (
   title TEXT NOT NULL,
   body TEXT NOT NULL,
   FOREIGN KEY (author_id) REFERENCES user (id)
+);
+
+CREATE TABLE lead (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  start_date TIMESTAMP,
+  end_date TIMESTAMP,
+  amount REAL,
+  probability REAL
 );

--- a/src/flask/flaskr/templates/base.html
+++ b/src/flask/flaskr/templates/base.html
@@ -18,6 +18,7 @@
         <ul class="navbar-nav ms-auto">
           {% if g.user %}
             <li class="nav-item"><span class="nav-link">{{ g.user['username'] }}</span></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('lead.index') }}">Leads</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Log Out</a></li>
           {% else %}
             <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.register') }}">Register</a></li>

--- a/src/flask/flaskr/templates/lead/create.html
+++ b/src/flask/flaskr/templates/lead/create.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block header %}
+  <h1>{% block title %}New Lead{% endblock %}</h1>
+{% endblock %}
+
+{% block content %}
+  <form method="post">
+    <label for="title">Title</label>
+    <input name="title" id="title" value="{{ request.form['title'] }}" required>
+    
+    <label for="start_date">Start Date</label>
+    <input type="date" name="start_date" id="start_date" value="{{ request.form['start_date'] }}">
+    
+    <label for="end_date">End Date</label>
+    <input type="date" name="end_date" id="end_date" value="{{ request.form['end_date'] }}">
+    
+    <label for="amount">Amount</label>
+    <input type="number" step="any" name="amount" id="amount" value="{{ request.form['amount'] }}">
+    
+    <label for="probability">Probability (0.0 to 1.0)</label>
+    <input type="number" step="0.01" min="0" max="1" name="probability" id="probability" value="{{ request.form['probability'] }}">
+    
+    <input type="submit" value="Save">
+  </form>
+{% endblock %}

--- a/src/flask/flaskr/templates/lead/index.html
+++ b/src/flask/flaskr/templates/lead/index.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+
+{% block header %}
+  <h1>{% block title %}Leads{% endblock %}</h1>
+  {% if g.user %}
+    <a class="action" href="{{ url_for('lead.create') }}">Add Lead</a>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+  <table>
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Start Date</th>
+        <th>End Date</th>
+        <th>Amount</th>
+        <th>Probability</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for lead in leads %}
+        <tr>
+          <td>{{ lead['title'] }}</td>
+          <td>{{ lead['start_date'] if lead['start_date'] is not none else 'N/A' }}</td>
+          <td>{{ lead['end_date'] if lead['end_date'] is not none else 'N/A' }}</td>
+          <td>{{ lead['amount'] if lead['amount'] is not none else 'N/A' }}</td>
+          <td>{{ lead['probability'] if lead['probability'] is not none else 'N/A' }}</td>
+          <td>
+            <a class="action" href="{{ url_for('lead.update', id=lead['id']) }}">Edit</a>
+            <form action="{{ url_for('lead.delete', id=lead['id']) }}" method="post" style="display: inline;">
+              <input type="submit" value="Delete" onclick="return confirm('Are you sure?');">
+            </form>
+          </td>
+        </tr>
+      {% else %}
+        <tr>
+          <td colspan="6">No leads found.</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/src/flask/flaskr/templates/lead/update.html
+++ b/src/flask/flaskr/templates/lead/update.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block header %}
+  <h1>{% block title %}Edit Lead{% endblock %}</h1>
+{% endblock %}
+
+{% block content %}
+  <form method="post">
+    <label for="title">Title</label>
+    <input name="title" id="title" value="{{ request.form['title'] or lead['title'] }}" required>
+    
+    <label for="start_date">Start Date</label>
+    <input type="date" name="start_date" id="start_date" value="{{ request.form['start_date'] or lead['start_date'] }}">
+    
+    <label for="end_date">End Date</label>
+    <input type="date" name="end_date" id="end_date" value="{{ request.form['end_date'] or lead['end_date'] }}">
+    
+    <label for="amount">Amount</label>
+    <input type="number" step="any" name="amount" id="amount" value="{{ request.form['amount'] or lead['amount'] }}">
+    
+    <label for="probability">Probability (0.0 to 1.0)</label>
+    <input type="number" step="0.01" min="0" max="1" name="probability" id="probability" value="{{ request.form['probability'] or lead['probability'] }}">
+    
+    <input type="submit" value="Save">
+  </form>
+{% endblock %}

--- a/src/flask/tests/test_lead.py
+++ b/src/flask/tests/test_lead.py
@@ -1,0 +1,333 @@
+import pytest
+from flaskr.db import get_db
+
+def test_index(client, auth):
+    response = client.get('/lead/')
+    assert response.status_code == 302 # Redirect to login
+    assert 'http://localhost/auth/login' in response.headers['Location']
+
+    auth.login()
+    response = client.get('/lead/')
+    assert response.status_code == 200
+    assert b'Leads' in response.data
+    assert b'Add Lead' in response.data
+    # Check for a lead added by a fixture or previous test if applicable
+    # For now, just check that the page loads and has expected static text
+
+    # Add a lead to check if it's displayed
+    with client.application.app_context():
+        db = get_db()
+        db.execute(
+            "INSERT INTO lead (title, start_date, end_date, amount, probability) VALUES (?, ?, ?, ?, ?)",
+            ('Test Lead for Index', '2024-01-01', '2024-01-31', 1000.0, 0.5),
+        )
+        db.commit()
+
+    response = client.get('/lead/')
+    assert b'Test Lead for Index' in response.data
+    assert b'2024-01-01' in response.data # Date formatting might make this tricky, adjust if needed
+    assert b'1000.0' in response.data 
+    assert b'0.5' in response.data
+
+
+@pytest.mark.parametrize(('path', 'expected_title'), (
+    ('/lead/create', b'New Lead'),
+    ('/lead/1/update', b'Edit Lead'), # Assumes lead with id 1 exists
+))
+def test_create_update_get_requires_login(client, path, expected_title):
+    response = client.get(path)
+    assert response.status_code == 302
+    assert 'http://localhost/auth/login' in response.headers['Location']
+
+# Need to ensure a lead with ID 1 exists for the update test case.
+# This can be done by creating a lead before this parameterized test runs,
+# or by ensuring 'test_update' specific tests handle creation.
+# For simplicity, we'll handle lead creation within test_update and test_delete.
+
+def test_create_get(client, auth):
+    auth.login()
+    response = client.get('/lead/create')
+    assert response.status_code == 200
+    assert b'New Lead' in response.data
+
+def test_create_post(client, auth, app):
+    auth.login()
+    response = client.post('/lead/create', data={
+        'title': 'New Test Lead',
+        'start_date': '2024-02-01',
+        'end_date': '2024-02-28',
+        'amount': '1500.50',
+        'probability': '0.75'
+    }, follow_redirects=True)
+    assert response.status_code == 200 # Should redirect to index
+    assert b'Leads' in response.data # Check if we are on index page
+    assert b'New Test Lead' in response.data # Check if new lead is listed
+
+    with app.app_context():
+        db = get_db()
+        lead = db.execute("SELECT * FROM lead WHERE title = 'New Test Lead'").fetchone()
+        assert lead is not None
+        assert lead['start_date'] == '2024-02-01' # Stored as TEXT
+        assert lead['amount'] == 1500.50
+        assert lead['probability'] == 0.75
+
+def test_create_post_title_required(client, auth, app):
+    auth.login()
+    response = client.post('/lead/create', data={
+        'title': '', # Empty title
+        'start_date': '2024-03-01',
+        'amount': '200'
+    })
+    assert response.status_code == 200 # No redirect, show form with error
+    assert b'Title is required.' in response.data
+
+    with app.app_context():
+        db = get_db()
+        # Ensure no lead was created with an empty title by this post
+        lead = db.execute("SELECT * FROM lead WHERE start_date = '2024-03-01'").fetchone()
+        assert lead is None
+
+def _create_test_lead(app, title="Update Me"):
+    with app.app_context():
+        db = get_db()
+        cursor = db.execute(
+            "INSERT INTO lead (title, start_date, end_date, amount, probability) VALUES (?, ?, ?, ?, ?)",
+            (title, '2024-01-10', '2024-01-20', 500.0, 0.25),
+        )
+        db.commit()
+        return cursor.lastrowid # Return the id of the created lead
+
+def test_update_get(client, auth, app):
+    lead_id = _create_test_lead(app)
+    
+    # Test get update page when not logged in
+    response = client.get(f'/lead/{lead_id}/update')
+    assert response.status_code == 302
+    assert 'http://localhost/auth/login' in response.headers['Location']
+
+    auth.login()
+    response = client.get(f'/lead/{lead_id}/update')
+    assert response.status_code == 200
+    assert b'Edit Lead' in response.data
+    assert b'Update Me' in response.data # Original title
+
+def test_update_post(client, auth, app):
+    lead_id = _create_test_lead(app, title="Original Title for Update")
+    auth.login()
+    
+    response = client.post(f'/lead/{lead_id}/update', data={
+        'title': 'Updated Test Lead',
+        'start_date': '2024-03-01',
+        'end_date': '2024-03-31',
+        'amount': '2500.75',
+        'probability': '0.90'
+    }, follow_redirects=True)
+    
+    assert response.status_code == 200
+    assert b'Leads' in response.data # Redirected to index
+    assert b'Updated Test Lead' in response.data
+
+    with app.app_context():
+        db = get_db()
+        lead = db.execute("SELECT * FROM lead WHERE id = ?", (lead_id,)).fetchone()
+        assert lead is not None
+        assert lead['title'] == 'Updated Test Lead'
+        assert lead['start_date'] == '2024-03-01'
+        assert lead['amount'] == 2500.75
+        assert lead['probability'] == 0.90
+
+def test_update_post_title_required(client, auth, app):
+    lead_id = _create_test_lead(app, title="Title Required Test")
+    auth.login()
+
+    response = client.post(f'/lead/{lead_id}/update', data={
+        'title': '', # Empty title
+        'start_date': '2024-04-01',
+        'amount': '300'
+    })
+    assert response.status_code == 200 # No redirect
+    assert b'Title is required.' in response.data
+
+    with app.app_context():
+        db = get_db()
+        lead = db.execute("SELECT * FROM lead WHERE id = ?", (lead_id,)).fetchone()
+        assert lead is not None
+        assert lead['title'] == 'Title Required Test' # Title should not have changed
+
+def test_update_non_existent(client, auth, app):
+    auth.login()
+    response = client.get('/lead/999/update')
+    assert response.status_code == 404
+    response = client.post('/lead/999/update', data={'title': 'ghost'})
+    assert response.status_code == 404
+
+
+def test_delete(client, auth, app):
+    lead_id = _create_test_lead(app, title="To Be Deleted")
+    
+    # Test delete when not logged in
+    response = client.post(f'/lead/{lead_id}/delete')
+    assert response.status_code == 302 # Redirect to login
+    assert 'http://localhost/auth/login' in response.headers['Location']
+
+    auth.login()
+    response = client.post(f'/lead/{lead_id}/delete', follow_redirects=True)
+    assert response.status_code == 200
+    assert b'Leads' in response.data # Redirected to index
+    assert b'To Be Deleted' not in response.data # Lead should be gone
+
+    with app.app_context():
+        db = get_db()
+        lead = db.execute("SELECT * FROM lead WHERE id = ?", (lead_id,)).fetchone()
+        assert lead is None
+
+def test_delete_non_existent(client, auth, app):
+    auth.login()
+    # Ensure lead 999 does not exist (or any other high number)
+    with app.app_context():
+        db = get_db()
+        db.execute("DELETE FROM lead WHERE id = 999")
+        db.commit()
+        
+    response = client.post('/lead/999/delete')
+    assert response.status_code == 404
+
+# Parameterized test for paths that require a lead to exist and user to be logged in for GET
+@pytest.mark.parametrize('path_template', (
+    '/lead/{id}/update',
+))
+def test_get_lead_specific_paths_auth_and_existence(client, auth, app, path_template):
+    # Test access when not logged in
+    response = client.get(path_template.format(id=1)) # Use arbitrary ID
+    assert response.status_code == 302
+    assert 'http://localhost/auth/login' in response.headers['Location']
+
+    auth.login()
+    # Test access to non-existent lead
+    response = client.get(path_template.format(id=999)) # Use non-existent ID
+    assert response.status_code == 404
+
+    # Test access to existing lead
+    lead_id = _create_test_lead(app, "Access Test Lead")
+    response = client.get(path_template.format(id=lead_id))
+    assert response.status_code == 200
+    if "update" in path_template:
+        assert b"Edit Lead" in response.data
+        assert b"Access Test Lead" in response.data
+
+# Parameterized test for POST actions on specific leads that require login and lead existence
+@pytest.mark.parametrize('path_template', (
+    '/lead/{id}/delete',
+))
+def test_post_lead_specific_paths_auth_and_existence(client, auth, app, path_template):
+    # Test action when not logged in
+    response = client.post(path_template.format(id=1)) # Use arbitrary ID
+    assert response.status_code == 302
+    assert 'http://localhost/auth/login' in response.headers['Location']
+
+    auth.login()
+    # Test action on non-existent lead
+    response = client.post(path_template.format(id=999)) # Use non-existent ID
+    assert response.status_code == 404
+
+    # Test action on existing lead (delete will be tested more thoroughly in test_delete)
+    # This is more of a general check for the decorator/get_lead logic
+    if "delete" in path_template: # This is the only one for now
+        lead_id = _create_test_lead(app, "Delete Action Test Lead")
+        response = client.post(path_template.format(id=lead_id), follow_redirects=True)
+        assert response.status_code == 200
+        assert b'Leads' in response.data # Should redirect to index
+        with app.app_context():
+            db = get_db()
+            lead = db.execute("SELECT * FROM lead WHERE id = ?", (lead_id,)).fetchone()
+            assert lead is None
+    # Add other POST actions like 'publish', 'archive' if they were part of lead module
+    # For now, only delete fits this pattern of POSTing to /lead/<id>/action
+
+@pytest.mark.parametrize(('amount_in', 'probability_in', 'expected_amount', 'expected_probability', 'error_expected'), (
+    ('100.50', '0.5', 100.50, 0.5, None),
+    ('', '', None, None, None), # Optional fields
+    ('abc', '0.5', None, 0.5, b'Invalid amount.'),
+    ('100', 'xyz', 100.0, None, b'Invalid probability.'),
+    ('abc', 'xyz', None, None, b'Invalid amount. Invalid probability.'), # Check multiple errors
+))
+def test_create_optional_fields_validation(client, auth, app, amount_in, probability_in, expected_amount, expected_probability, error_expected):
+    auth.login()
+    response = client.post('/lead/create', data={
+        'title': 'Validation Test',
+        'start_date': '2024-05-01',
+        'end_date': '2024-05-31',
+        'amount': amount_in,
+        'probability': probability_in
+    }, follow_redirects=True)
+
+    if error_expected:
+        assert response.status_code == 200 # Should stay on create page
+        assert error_expected in response.data
+        with app.app_context():
+            db = get_db()
+            lead = db.execute("SELECT * FROM lead WHERE title = 'Validation Test'").fetchone()
+            assert lead is None # Should not be created
+    else:
+        assert response.status_code == 200 # Successful creation redirects to index
+        assert b'Leads' in response.data
+        assert b'Validation Test' in response.data
+        with app.app_context():
+            db = get_db()
+            lead = db.execute("SELECT * FROM lead WHERE title = 'Validation Test'").fetchone()
+            assert lead is not None
+            assert lead['amount'] == expected_amount
+            assert lead['probability'] == expected_probability
+
+def test_update_optional_fields_validation(client, auth, app):
+    lead_id = _create_test_lead(app, title="Update Validation Test")
+    auth.login()
+
+    # First, check successful update with empty optional fields
+    response = client.post(f'/lead/{lead_id}/update', data={
+        'title': 'Updated Validation Test',
+        'start_date': '',
+        'end_date': '',
+        'amount': '',
+        'probability': ''
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    assert b'Leads' in response.data
+    assert b'Updated Validation Test' in response.data
+
+    with app.app_context():
+        db = get_db()
+        lead = db.execute("SELECT * FROM lead WHERE id = ?", (lead_id,)).fetchone()
+        assert lead is not None
+        assert lead['title'] == 'Updated Validation Test'
+        assert lead['start_date'] is None
+        assert lead['end_date'] is None
+        assert lead['amount'] is None
+        assert lead['probability'] is None
+
+    # Test invalid amount during update
+    response = client.post(f'/lead/{lead_id}/update', data={
+        'title': 'Updated Validation Test',
+        'amount': 'invalid_amount',
+        'probability': '0.5'
+    })
+    assert response.status_code == 200 # Stays on update page
+    assert b'Invalid amount.' in response.data
+    
+    # Test invalid probability during update
+    response = client.post(f'/lead/{lead_id}/update', data={
+        'title': 'Updated Validation Test',
+        'amount': '100.0',
+        'probability': 'invalid_prob'
+    })
+    assert response.status_code == 200 # Stays on update page
+    assert b'Invalid probability.' in response.data
+
+    # Ensure original data (or last valid update) is still there
+    with app.app_context():
+        db = get_db()
+        lead = db.execute("SELECT * FROM lead WHERE id = ?", (lead_id,)).fetchone()
+        assert lead is not None
+        assert lead['title'] == 'Updated Validation Test' # Title from successful update
+        assert lead['amount'] is None # From successful update with empty fields
+        assert lead['probability'] is None # From successful update with empty fields


### PR DESCRIPTION
This commit introduces a new feature to track leads within the application.

Key changes include:
- Added a `lead` table to the database schema with fields: id, title, start_date, end_date, amount, and probability.
- Implemented a new Flask blueprint (`lead.py`) providing CRUD operations:
    - List all leads (`/lead/`)
    - Create new leads (`/lead/create`)
    - Update existing leads (`/lead/<id>/update`)
    - Delete leads (`/lead/<id>/delete`)
- Created corresponding HTML templates for lead listing, creation, and editing forms.
- Registered the `lead` blueprint in the main application.
- Added a "Leads" link to the main navigation for logged-in users.
- Implemented comprehensive unit tests (`test_lead.py`) for all CRUD operations, including validation and access control.
- Added end-to-end tests (`test_e2e.py`) using Playwright to cover user workflows for adding, editing, and deleting leads through the UI.
- Ensured database initialization (`init-db`) correctly incorporates the new `lead` table.